### PR TITLE
Add StageName property to ApiGatewayDeployment resource

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -147,6 +147,7 @@ Resources:
       - ApiGatewayRootMethod
     Properties:
       RestApiId: !Ref ApiGateway
+      StageName: Prod
 
   # Glue Analytics
 


### PR DESCRIPTION
This should automatically create a Stage, without us having to add an AWS::ApiGateway::Stage resource to the template.yaml.